### PR TITLE
Improve how the status column works

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,8 +1,5 @@
-name: PR Checks 
-
-on:
-  pull_request
-  
+name: PR Checks
+on: pull_request
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -13,20 +10,10 @@ jobs:
           ref: ${{ github.head_ref }}
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
-      - uses: actions/cache@v1
         with:
-          path: vendor/bundle
-          key: bundle-use-ruby-${{ hashFiles('.ruby-version') }}-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            bundle-use-ruby-${{ hashFiles('.ruby-version') }}-
-      - name: Install dependencies
-        run: |
-          sudo apt-get -yqq install libpq-dev
-          gem install bundler -v '2.1.2'
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          ruby-version: 2.7
+          bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop
       - name: Run specs
         run: bundle exec rspec spec/
-        

--- a/lib/sequel/plugins/state_machine.rb
+++ b/lib/sequel/plugins/state_machine.rb
@@ -72,8 +72,8 @@ module Sequel
           audlog.set(
             at: Time.now,
             event: event,
-            from_state: self.status,
-            to_state: self.status,
+            from_state: self[self._state_value_attr],
+            to_state: self[self._state_value_attr],
             messages: audlog.class.state_machine_messages_supports_array ? messages : messages.join("\n"),
             reason: reason || "",
             actor: StateMachines::Sequel.current_actor,

--- a/lib/sequel/plugins/state_machine.rb
+++ b/lib/sequel/plugins/state_machine.rb
@@ -7,7 +7,53 @@ require "state_machines/sequel"
 module Sequel
   module Plugins
     module StateMachine
+      class InvalidConfiguration < RuntimeError; end
+
+      def self.apply(_model, _opts={})
+        nil
+      end
+
+      def self.configure(model, opts={})
+        col = opts.is_a?(Symbol) ? opts : nil
+        model.instance_eval do
+          # See state_machine_status_column.
+          # We must defer defaulting the value in case the plugin
+          # comes ahead of the state  machine (we can see a valid state machine,
+          # but the attribute/name will always be :state, due to some configuration
+          # order of operations).
+          @sequel_state_machine_status_column = col if col
+        end
+      end
+
       module InstanceMethods
+        private def state_machine_status_column
+          col = self.class.instance_variable_get(:@sequel_state_machine_status_column)
+          return col unless col.nil?
+          if self.respond_to?(:_state_value_attr)
+            self.class.instance_variable_set(:@sequel_state_machine_status_column, self._state_value_attr)
+            return self._state_value_attr
+          end
+          if !self.class.respond_to?(:state_machines) || self.class.state_machines.empty?
+            msg = "Model must extend StateMachines::MacroMethods and have one state_machine."
+            raise InvalidConfiguration, msg
+          end
+          if self.class.state_machines.length > 1
+            msg = "Cannot use sequel-state-machine with multiple state machines. " \
+                  "Please file an issue at https://github.com/lithictech/sequel-state-machine/issues " \
+                  "if you need this capability."
+            raise InvalidConfiguration, msg
+          end
+          self.class.instance_variable_set(:@sequel_state_machine_status_column, self.class.state_machine.attribute)
+        end
+
+        private def state_machine_status
+          return self.send(self.state_machine_status_column)
+        end
+
+        def sequel_state_machine_status
+          return state_machine_status
+        end
+
         def new_audit_log
           audit_log_assoc = self.class.association_reflections[:audit_logs]
           model = Kernel.const_get(audit_log_assoc[:class_name])
@@ -72,8 +118,8 @@ module Sequel
           audlog.set(
             at: Time.now,
             event: event,
-            from_state: self[self._state_value_attr],
-            to_state: self[self._state_value_attr],
+            from_state: self.state_machine_status,
+            to_state: self.state_machine_status,
             messages: audlog.class.state_machine_messages_supports_array ? messages : messages.join("\n"),
             reason: reason || "",
             actor: StateMachines::Sequel.current_actor,
@@ -114,25 +160,24 @@ module Sequel
 
         # Return true if the given event can be transitioned into by the current state.
         def valid_state_path_through?(event)
-          current_state = self.send(self._state_value_attr).to_sym
+          current_state_str = self.state_machine_status.to_s
+          current_state_sym = current_state_str.to_sym
           event_obj = self.class.state_machine.events[event] or raise "Invalid event #{event}"
           event_obj.branches.each do |branch|
             branch.state_requirements.each do |state_req|
-              return true if state_req[:from]&.matches?(current_state)
+              next unless (from = state_req[:from])
+              return true if from.matches?(current_state_str) || from.matches?(current_state_sym)
             end
           end
           return false
         end
 
-        def _state_value_attr
-          return @_state_value_attr ||= self.class.state_machine.attribute
-        end
-
         def validates_state_machine
           states = self.class.state_machine.states.map(&:value)
-          state = self[self._state_value_attr]
+          state = self.state_machine_status
           return if states.include?(state)
-          self.errors.add(self._state_value_attr, "status '#{state}' must be one of (#{states.sort.join(', ')})")
+          self.errors.add(self.state_machine_status_column,
+                          "state '#{state}' must be one of (#{states.sort.join(', ')})",)
         end
       end
 

--- a/lib/sequel/plugins/state_machine_audit_log.rb
+++ b/lib/sequel/plugins/state_machine_audit_log.rb
@@ -36,14 +36,14 @@ module Sequel
 
       module DatasetMethods
         def failed
-          colmap = self.state_machine_column_mappings
+          colmap = self.model.state_machine_column_mappings
           tostate_col = colmap[:to_state]
           fromstate_col = colmap[:from_state]
           return self.where(tostate_col => fromstate_col)
         end
 
         def succeeded
-          colmap = self.state_machine_column_mappings
+          colmap = self.model.state_machine_column_mappings
           tostate_col = colmap[:to_state]
           fromstate_col = colmap[:from_state]
           return self.exclude(tostate_col => fromstate_col)

--- a/lib/state_machines/sequel/spec_helpers.rb
+++ b/lib/state_machines/sequel/spec_helpers.rb
@@ -6,7 +6,7 @@ RSpec::Matchers.define :transition_on do |event|
   match do |receiver|
     raise 'must provide a "to" state' if (@to || "").to_s.empty?
     receiver.send(event, *@args)
-    @to == receiver[receiver._state_value_attr]
+    @to == receiver.send(:state_machine_status)
   end
 
   chain :to do |to_state|
@@ -22,12 +22,11 @@ RSpec::Matchers.define :transition_on do |event|
   end
 
   failure_message do |receiver|
-    receiver_status = receiver[receiver._state_value_attr]
     msg =
-      if @to == receiver_status
+      if @to == receiver.state_machine_status
         "expected that event #{event} would transition, but did not"
       else
-        "expected that event #{event} would transition to #{@to} but is #{receiver_status}"
+        "expected that event #{event} would transition to #{@to} but is #{receiver.state_machine_status}"
       end
     (msg += "\n#{receiver.audit_logs.map(&:inspect).join("\n")}") if @audit
     msg
@@ -44,7 +43,7 @@ RSpec::Matchers.define :not_transition_on do |event|
   end
 
   failure_message do |receiver|
-    "expected that event #{event} would not transition, but did and is now #{receiver[receiver._state_value_attr]}"
+    "expected that event #{event} would not transition, but did and is now #{receiver.state_machine_status}"
   end
 end
 

--- a/lib/state_machines/sequel/spec_helpers.rb
+++ b/lib/state_machines/sequel/spec_helpers.rb
@@ -6,7 +6,7 @@ RSpec::Matchers.define :transition_on do |event|
   match do |receiver|
     raise 'must provide a "to" state' if (@to || "").to_s.empty?
     receiver.send(event, *@args)
-    @to == receiver.status
+    @to == receiver[receiver._state_value_attr]
   end
 
   chain :to do |to_state|
@@ -22,11 +22,12 @@ RSpec::Matchers.define :transition_on do |event|
   end
 
   failure_message do |receiver|
+    receiver_status = receiver[receiver._state_value_attr]
     msg =
-      if @to == receiver.status
+      if @to == receiver_status
         "expected that event #{event} would transition, but did not"
       else
-        "expected that event #{event} would transition to #{@to} but is #{receiver.status}"
+        "expected that event #{event} would transition to #{@to} but is #{receiver_status}"
       end
     (msg += "\n#{receiver.audit_logs.map(&:inspect).join("\n")}") if @audit
     msg
@@ -43,7 +44,7 @@ RSpec::Matchers.define :not_transition_on do |event|
   end
 
   failure_message do |receiver|
-    "expected that event #{event} would not transition, but did and is now #{receiver.status}"
+    "expected that event #{event} would not transition, but did and is now #{receiver[receiver._state_value_attr]}"
   end
 end
 

--- a/lib/state_machines/sequel/spec_helpers.rb
+++ b/lib/state_machines/sequel/spec_helpers.rb
@@ -49,6 +49,7 @@ RSpec::Matchers.define :not_transition_on do |event|
 end
 
 RSpec.shared_examples "a state machine with audit logging" do |event, to_state|
+  let(:machine) { raise NotImplementedError, "must override let(:machine)" }
   it "logs transitions" do
     expect(machine).to transition_on(event).to(to_state)
     expect(machine.audit_logs).to contain_exactly(

--- a/sequel-state-machine.gemspec
+++ b/sequel-state-machine.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rubocop-performance", "~> 1.10")
   s.add_development_dependency("rubocop-sequel", "~> 0.2")
   s.add_development_dependency("sequel", "~> 5.0")
+  s.add_development_dependency("simplecov", "~> 0")
   s.add_development_dependency("sqlite3", "~> 1")
   s.add_development_dependency("state_machines", "~> 0")
+  s.add_development_dependency("timecop", "~> 0")
 end

--- a/spec/sequel_state_machine_spec.rb
+++ b/spec/sequel_state_machine_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "sequel-state-machine", :db do
     end
     @db.create_table(:charges) do
       primary_key :id
-      text :status, null: false, default: "created"
+      text :status_col, null: false, default: "created"
       real :total, null: false, default: 0
       text :charge_status, null: false, default: ""
     end

--- a/spec/spec_models.rb
+++ b/spec/spec_models.rb
@@ -4,74 +4,76 @@ require "state_machines"
 
 # Type that can be used for unit testing state machine helpers.
 module SequelStateMachine
-  class SpecModel < Sequel::Model(:spec_models)
-    extend StateMachines::MacroMethods
-    plugin :state_machine
+  module SpecModels
+    class Charge < Sequel::Model(:charges)
+      extend StateMachines::MacroMethods
+      plugin :state_machine
 
-    class User < Sequel::Model(:spec_model_users)
+      one_to_many :audit_logs, class: "SequelStateMachine::SpecModels::ChargeAuditLog", order: Sequel.desc(:at)
+
+      state_machine :status, initial: :pending do
+        state :pending,
+              :open,
+              :charged,
+              :paid,
+              :failed
+
+        event :finalize do
+          transition pending: :open
+        end
+
+        event :charge do
+          transition open: :paid, if: :total_zero?
+          transition [:open, :charged] => :paid, if: :charge_paid?
+          transition [:open, :charged] => :failed, if: :charge_failed?
+          transition open: :charged, if: :charge_in_progress?
+        end
+
+        event :set_failed do
+          transition any => :failed
+        end
+
+        after_transition(&:commit_audit_log)
+        after_failure(&:commit_audit_log)
+      end
+
+      timestamp_accessors(
+        [
+          [{event: "charge", from: "open", to: "charged"}, :charged_at],
+          [{to: "paid"}, :paid_at],
+        ],
+      )
+
+      def total_zero?
+        return self.total.zero?
+      end
+
+      def charge_paid?
+        return self.charge_status == "paid"
+      end
+
+      def charge_in_progress?
+        return self.charge_status == "pending"
+      end
+
+      def charge_failed?
+        return self.charge_status == "failed"
+      end
+
+      def validate
+        super
+        self.validates_state_machine
+      end
     end
 
-    class AuditLog < Sequel::Model(:spec_model_audit_logs)
+    class User < Sequel::Model(:users)
+    end
+
+    class ChargeAuditLog < Sequel::Model(:charge_audit_logs)
       plugin :state_machine_audit_log
 
-      many_to_one :helper, class: "SequelStateMachine::SpecModel"
-      many_to_one :actor, class: "SequelStateMachine::SpecModel::User"
-    end
-
-    one_to_many :audit_logs, class: "SequelStateMachine::SpecModel::AuditLog", order: Sequel.desc(:at)
-
-    state_machine :status, initial: :pending do
-      state :pending,
-            :open,
-            :charged,
-            :paid,
-            :failed
-
-      event :finalize do
-        transition pending: :open
-      end
-
-      event :charge do
-        transition open: :paid, if: :total_zero?
-        transition [:open, :charged] => :paid, if: :charge_paid?
-        transition [:open, :charged] => :failed, if: :charge_failed?
-        transition open: :charged, if: :charge_in_progress?
-      end
-
-      event :set_failed do
-        transition any => :failed
-      end
-
-      after_transition(&:commit_audit_log)
-      after_failure(&:commit_audit_log)
-    end
-
-    timestamp_accessors(
-      [
-        [{event: "charge", from: "open", to: "charged"}, :charged_at],
-        [{to: "paid"}, :paid_at],
-      ],
-    )
-
-    def total_zero?
-      return self.total.zero?
-    end
-
-    def charge_paid?
-      return self.charge_status == "paid"
-    end
-
-    def charge_in_progress?
-      return self.charge_status == "pending"
-    end
-
-    def charge_failed?
-      return self.charge_status == "failed"
-    end
-
-    def validate
-      super
-      self.validates_state_machine
+      many_to_one :charge, class: "SequelStateMachine::SpecModels::Charge"
+      many_to_one :actor, class: "SequelStateMachine::SpecModels::User"
     end
   end
 end

--- a/spec/spec_models.rb
+++ b/spec/spec_models.rb
@@ -11,7 +11,7 @@ module SequelStateMachine
 
       one_to_many :audit_logs, class: "SequelStateMachine::SpecModels::ChargeAuditLog", order: Sequel.desc(:at)
 
-      state_machine :status, initial: :pending do
+      state_machine :status_col, initial: :pending do
         state :pending,
               :open,
               :charged,

--- a/spec/spec_models.rb
+++ b/spec/spec_models.rb
@@ -39,8 +39,10 @@ module SequelStateMachine
 
       timestamp_accessors(
         [
+          [{to: "open"}, :finalized_at],
           [{event: "charge", from: "open", to: "charged"}, :charged_at],
           [{to: "paid"}, :paid_at],
+          [{to: "failed"}, :failed_at],
         ],
       )
 


### PR DESCRIPTION
Make it idiomatic for how Sequel generally works.
Maintain support for previous pattern
using a protected method.

Fix a few bugs where we were assuming a specific status column name.

Greatly improve tests.